### PR TITLE
add an new macro "_WINDOWS_INCLUDED_DISK" 

### DIFF
--- a/pack/commands.cfg
+++ b/pack/commands.cfg
@@ -6,7 +6,7 @@
 # and -3 is for printong in output bad states first
 define command {
        command_name	check_windows_disks
-       command_line	$PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checkdrivesize -a '.'  -w $_HOSTWINDOWS_DISK_WARN$ -c $_HOSTWINDOWS_DISK_CRIT$ -o 0 -3 1  --inidir=$PLUGINSDIR$
+       command_line	$PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checkdrivesize -a '$_HOSTWINDOWS_INCLUDED_DISK$'  -w $_HOSTWINDOWS_DISK_WARN$ -c $_HOSTWINDOWS_DISK_CRIT$ -o 0 -3 1  --inidir=$PLUGINSDIR$
 }
 
 

--- a/pack/templates.cfg
+++ b/pack/templates.cfg
@@ -11,6 +11,7 @@ define host{
    _DOMAINUSER                      $_HOSTDOMAIN$\\$_HOSTDOMAINUSERSHORT$
    _DOMAINPASSWORD                  $DOMAINPASSWORD$
 
+   _WINDOWS_INCLUDED_DISK           .
    _WINDOWS_DISK_WARN               90
    _WINDOWS_DISK_CRIT               95
    _WINDOWS_EVENT_LOG_WARN          1

--- a/pack/windows.pack
+++ b/pack/windows.pack
@@ -28,6 +28,9 @@
          "_EXCLUDED_SERVICES": {"type":"string",
                                 "description": "Regex for services to be excluded from check auto services"
                              },
+         "_WINDOWS_INCLUDED_DISK": {"type":"string",
+                             "description":"List of disk included in the check_windows_disks. by default, all disks are included"
+                             },
          "_WINDOWS_DISK_WARN": {"type":"percent",
                              "description":"Level for disk space"
                              },


### PR DESCRIPTION
add an new macro "_WINDOWS_INCLUDED_DISK" to define the list of disks to check with the commande check_windows_disks
